### PR TITLE
Json type property

### DIFF
--- a/lib/trax/core/types.rb
+++ b/lib/trax/core/types.rb
@@ -9,8 +9,9 @@ module Trax
       autoload :EnumValue
       autoload :Float
       autoload :Integer
-      autoload :Struct
+      autoload :Json
       autoload :String
+      autoload :Struct
       autoload :ValueObject
     end
   end

--- a/lib/trax/core/types/json.rb
+++ b/lib/trax/core/types/json.rb
@@ -1,0 +1,8 @@
+module Trax
+  module Core
+    module Types
+      class Json
+      end
+    end
+  end
+end

--- a/lib/trax/core/types/json.rb
+++ b/lib/trax/core/types/json.rb
@@ -2,6 +2,9 @@ module Trax
   module Core
     module Types
       class Json
+        def self.type
+          :json
+        end
       end
     end
   end

--- a/lib/trax/core/types/struct.rb
+++ b/lib/trax/core/types/struct.rb
@@ -17,11 +17,12 @@ module Trax
         DEFAULT_VALUES_FOR_PROPERTY_TYPES = {
           :array   => [],
           :boolean => nil,
-          :float   => 0.0,
-          :string  => "",
-          :struct  => {},
           :enum    => nil,
-          :integer => nil
+          :float   => 0.0,
+          :integer => nil,
+          :json   => {},
+          :string  => "",
+          :struct  => {}
         }.with_indifferent_access.freeze
 
         def self.fields_module
@@ -59,6 +60,10 @@ module Trax
           define_attribute_class_for_type(:integer, name, *args, :coerce => ::Integer, **options, &block)
         end
 
+        def self.json_property(name, *args, **options, &block)
+          define_attribute_class_for_type(:json, name, *args, **options, &block)
+        end
+
         def self.string_property(name, *args, **options, &block)
           define_attribute_class_for_type(:string, name, *args, :coerce => ::String, **options, &block)
         end
@@ -94,8 +99,9 @@ module Trax
           alias :enum :enum_property
           alias :float :float_property
           alias :integer :integer_property
-          alias :struct :struct_property
+          alias :json :json_property
           alias :string :string_property
+          alias :struct :struct_property
         end
 
         def value

--- a/spec/trax/core/types/struct_spec.rb
+++ b/spec/trax/core/types/struct_spec.rb
@@ -13,6 +13,9 @@ describe ::Trax::Core::Types::Struct do
         struct :territories do
           string :en, :default => "US"
         end
+
+        json :phone_formats
+        json :date_formats, :default => {:en_US => "%m-%d-%y"}
       end
     end
   end
@@ -23,11 +26,25 @@ describe ::Trax::Core::Types::Struct do
   it { expect(subject.en).to eq "something" }
   it { expect(subject.da).to eq "" }
   it { expect(subject.ca).to eq "eh" }
+
   it { expect(subject.territories.en).to eq "US" }
+
+  it { expect(subject.phone_formats).to eq({}) }
+  it { expect(subject.date_formats).to eq('en_US' => "%m-%d-%y") }
 
   context "unknown value" do
     subject { "::MyFakeStructNamespace::Locale".constantize.new(:blah => "something") }
     it { expect(subject).to_not respond_to(:blah) }
     it { expect(subject.en).to eq "" }
+  end
+
+  context "with json property" do
+    let(:locale) { :en_GB }
+    let(:date_format) { "%d/%m/%Y" }
+    let(:definition){ "::MyFakeStructNamespace::Locale".constantize.new(:date_formats => {locale => date_format}) }
+    subject { definition.date_formats }
+
+    it { expect(subject[locale.to_s]).to eq date_format }
+    it { expect(subject[locale.to_sym]).to eq date_format }
   end
 end


### PR DESCRIPTION
Useful for unstructured data within the struct property.

In the future, may want to add support of coercing key values to string to match the way json keys are handled in Javascript
