### PR TITLE
naming the option key extend was a really bad idea, change to extend

### DIFF
--- a/lib/trax/core/definitions.rb
+++ b/lib/trax/core/definitions.rb
@@ -6,8 +6,8 @@ module Trax
       end
 
       def enum(klass_name, **options, &block)
-        attribute_klass = if options.key?(:extend)
-          _klass_prototype = options[:extend].constantize.clone
+        attribute_klass = if options.key?(:extends)
+          _klass_prototype = options[:extends].constantize.clone
           ::Trax::Core::NamedClass.new("#{self.name}::#{klass_name}", _klass_prototype, :parent_definition => self, &block)
         else
           ::Trax::Core::NamedClass.new("#{self.name}::#{klass_name}", ::Trax::Core::Types::Enum, :parent_definition => self, &block)
@@ -17,8 +17,8 @@ module Trax
       end
 
       def struct(klass_name, **options, &block)
-        attribute_klass = if options.key?(:extend)
-          _klass_prototype = options[:extend].constantize.clone
+        attribute_klass = if options.key?(:extends)
+          _klass_prototype = options[:extends].constantize.clone
           ::Trax::Core::NamedClass.new("#{self.name}::#{klass_name}", _klass_prototype, :parent_definition => self, &block)
         else
           ::Trax::Core::NamedClass.new("#{self.name}::#{klass_name}", ::Trax::Core::Types::Struct, :parent_definition => self, &block)

--- a/lib/trax/core/types/struct.rb
+++ b/lib/trax/core/types/struct.rb
@@ -146,8 +146,8 @@ module Trax
           name = name.is_a?(::Symbol) ? name.to_s : name
           klass_name = "#{fields_module.name.underscore}/#{property_name}".camelize
 
-          attribute_klass = if options.key?(:extend)
-            _klass_prototype = options[:extend].is_a?(::String) ? options[:extend].safe_constantize : options[:extend]
+          attribute_klass = if options.key?(:extends)
+            _klass_prototype = options[:extends].is_a?(::String) ? options[:extends].safe_constantize : options[:extends]
             _klass = ::Trax::Core::NamedClass.new(klass_name, _klass_prototype, :parent_definition => self, **options, &block)
             _klass
           else

--- a/spec/support/defs.rb
+++ b/spec/support/defs.rb
@@ -16,7 +16,7 @@ module Defs
     array :categories, :of => "Defs::Category", :default => []
   end
 
-  struct :ShoesAttributes, :extend => "Defs::ProductAttributes" do
+  struct :ShoesAttributes, :extends => "Defs::ProductAttributes" do
     enum :size do
       define :mens_8,  1
       define :mens_9,  2

--- a/spec/trax/core/types/enum_spec.rb
+++ b/spec/trax/core/types/enum_spec.rb
@@ -18,7 +18,7 @@ describe ::Trax::Core::Types::Enum do
         define :accessories, 4
       end
 
-      enum :ExtendedCategory, :extend => "MyFakeEnumNamespace::Category" do
+      enum :ExtendedCategory, :extends => "MyFakeEnumNamespace::Category" do
         define :watches,    5
         define :sunglasses, 6
       end
@@ -125,7 +125,7 @@ describe ::Trax::Core::Types::Enum do
       let(:described_object) do
         "::MyFakeEnumNamespace::Category".constantize
       end
-      
+
       it { expect(described_object.names).to_not include(:watches)}
     end
   end


### PR DESCRIPTION
fix nasty bug when extending enum, caused by using extend and it overwriting the extend method
