### PR TITLE
Fix inheritance for configurations

### DIFF
--- a/lib/trax/core/configuration.rb
+++ b/lib/trax/core/configuration.rb
@@ -90,7 +90,13 @@ module Trax
         self.class.configurable_options.select{|attr_name, hash| hash.key?(:default) }.each_pair do |attr_name, hash|
           parent_context = self.class.parent_name.try(:constantize) if self.class.try(:parent_name)
 
-          default_value_for_option = hash[:default].is_a?(Proc) ? self.instance_exec(parent_context, &hash[:default]) : hash[:default]
+          default_value_for_option = if hash[:default].is_a?(Proc)
+            hash[:default].arity > 0 ? self.instance_exec(parent_context, &hash[:default])
+                                     : self.instance_exec(&hash[:default])
+          else
+            hash[:default]
+          end
+
           __send__("#{attr_name}=", default_value_for_option)
         end
       end

--- a/lib/trax/core/ext/class.rb
+++ b/lib/trax/core/ext/class.rb
@@ -1,4 +1,10 @@
 class Class
+  def detect_in_chain(bottom_klass = self, &block)
+    result = bottom_klass.instance_eval(&block)
+    return result if result
+    detect_in_chain(bottom_klass.superclass, &block)
+  end
+
   def superclasses_until(klass, bottom_klass=self, superclass_chain = [])
     if bottom_klass.superclass != klass
       superclass_chain.unshift(bottom_klass.superclass)

--- a/spec/trax/core/ext/class_spec.rb
+++ b/spec/trax/core/ext/class_spec.rb
@@ -9,4 +9,42 @@ describe ::Class do
       ]
     end
   end
+
+  describe ".detect_in_chain" do
+    before(:all) do
+      class FakeParentKlass; @something = "anything" end
+      class FakeChildKlass < FakeParentKlass; end
+      class FakeGrandchildKlass < FakeChildKlass; end
+      class FakeGreatGrandchildKlass; @something = "somethingelse" end
+    end
+
+    subject { FakeChildKlass }
+
+    context "has ivar directly defined" do
+      subject { FakeParentKlass }
+
+      it { expect(subject.instance_variable_get(:"@something")).to eq "anything" }
+    end
+
+    context "child class without instance variable defined" do
+      subject { FakeChildKlass }
+
+      it { expect(subject.instance_variable_get(:"@something")).to be_nil }
+      it { expect(subject.detect_in_chain{ instance_variable_get(:"@something") }).to eq "anything" }
+    end
+
+    context "grandchild class without instance variable defined" do
+      subject { FakeGrandchildKlass }
+
+      it { expect(subject.instance_variable_get(:"@something")).to be_nil }
+      it { expect(subject.detect_in_chain{ instance_variable_get(:"@something") }).to eq "anything" }
+    end
+
+    context "great grandchild class with instance variable overridden" do
+      subject { FakeGreatGrandchildKlass }
+
+      it { expect(subject.instance_variable_get(:"@something")).to eq "somethingelse" }
+      it { expect(subject.detect_in_chain{ instance_variable_get(:"@something") }).to eq "somethingelse" }
+    end
+  end
 end

--- a/spec/trax/core/ext/object_spec.rb
+++ b/spec/trax/core/ext/object_spec.rb
@@ -10,6 +10,65 @@ describe ::Object do
     SomeFakeClass
   end
 
+  describe ".define_configuration_options" do
+    before(:all) do
+      class Shape < OpenStruct
+        class_attribute :some_measurement
+        self.some_measurement = 20
+
+        define_configuration_options!(:dimensions) do
+          option :size, :default => 0
+          option :weight, :default => 10
+          option :calculated, :default => lambda{ self.size + self.weight }
+          option :calculated_with_context, :default => lambda{|context| self.calculated + context.some_measurement }
+        end
+
+        define_configuration_options(:geometry) do
+          option :sides
+          option :subtype
+          option :vertices, :default => 10
+        end
+
+        configure_geometry do |config|
+          config.sides = 0
+        end
+      end
+
+      class Square < Shape
+        configure_geometry do |config|
+          config.sides = 4
+        end
+      end
+
+      class Triangle < Shape
+      end
+    end
+
+    subject { Shape }
+
+    it { expect(subject::DimensionsConfiguration.new).to be_a(Trax::Core::Configuration) }
+    it { expect(subject.dimensions_configuration.size).to eq 0 }
+    it { expect(subject.dimensions_configuration.weight).to eq 10 }
+    it { expect(subject.dimensions_configuration.calculated).to eq 10 }
+    it { expect(subject.dimensions_configuration.calculated_with_context).to eq 30 }
+    it { expect(subject.geometry_configuration.sides).to eq 0 }
+
+    context "inheritance" do
+      context "subclass calls configure" do
+        subject { Square }
+
+        it { expect(subject.geometry_configuration.sides).to eq 4 }
+        it { expect(subject.geometry_configuration.vertices).to eq 10 }
+      end
+
+      context "subclass does not call configure" do
+        subject { Triangle }
+
+        it { expect(subject.geometry_configuration.sides).to eq 0 }
+      end
+    end
+  end
+
   describe ".try_chain" do
     it "wraps multiple calls to try and calls try on return value" do
       expect(subject.try_chain(:name, :underscore)).to eq "some_fake_class"


### PR DESCRIPTION
Currently when defining configuration via configuration_for builder method, any subclass inheriting will be nil unless configure_whatever method gets called explicitly. This fixes that by adding a generic detect_in_chain method which traverses superclass until the block executes and returns a non nil value.