### PR TITLE
Only dup hash for transformer

### DIFF
--- a/lib/trax/core/transformer/transformer.rb
+++ b/lib/trax/core/transformer/transformer.rb
@@ -7,16 +7,27 @@ module Trax
       #if class does not have properties attributes it was an anonymous transformer created by a block,
       #otherwise it was inherited from normally and we dont want to wipe out existing attributes
       def self.inherited(subklass)
-        apply_class_attributes_to_subklass(subklass) unless subklass.try(:properties)
+        if(subklass.try(:properties))
+          apply_duplicated_class_attributes_to_subklass(subklass)
+        else
+          apply_blank_class_attributes_to_subklass(subklass)
+        end
       end
 
-      def self.apply_class_attributes_to_subklass(subklass)
+      def self.apply_blank_class_attributes_to_subklass(subklass)
         subklass.class_attribute :properties
         subklass.properties = {}.with_indifferent_access
         subklass.class_attribute :after_initialize_callbacks
         subklass.after_initialize_callbacks = ::Set.new
         subklass.class_attribute :after_transform_callbacks
         subklass.after_transform_callbacks = ::Set.new
+      end
+
+      #need to dup the existing class attributes else they will be modified on original
+      def self.apply_duplicated_class_attributes_to_subklass(subklass)
+        subklass.properties = subklass.properties.dup
+        subklass.after_initialize_callbacks = subklass.after_initialize_callbacks.dup
+        subklass.after_transform_callbacks = subklass.after_transform_callbacks.dup
       end
 
       def self.after_initialize(&block)

--- a/lib/trax/core/transformer/transformer.rb
+++ b/lib/trax/core/transformer/transformer.rb
@@ -51,7 +51,7 @@ module Trax
       end
 
       def initialize(obj={}, parent=nil)
-        @input = obj.dup
+        @input = obj.is_a?(::Hash) ? obj.dup : obj
         @output = {}.with_indifferent_access
         @parent = parent if parent
 

--- a/lib/trax/core/transformer/transformer.rb
+++ b/lib/trax/core/transformer/transformer.rb
@@ -4,7 +4,13 @@ module Trax
       include ::Trax::Core::CommonTransformerMethods
       attr_reader :input, :parent, :output
 
+      #if class does not have properties attributes it was an anonymous transformer created by a block,
+      #otherwise it was inherited from normally and we dont want to wipe out existing attributes
       def self.inherited(subklass)
+        apply_class_attributes_to_subklass(subklass) unless subklass.try(:properties)
+      end
+
+      def self.apply_class_attributes_to_subklass(subklass)
         subklass.class_attribute :properties
         subklass.properties = {}.with_indifferent_access
         subklass.class_attribute :after_initialize_callbacks

--- a/spec/trax/core/transformer_spec.rb
+++ b/spec/trax/core/transformer_spec.rb
@@ -81,6 +81,11 @@ describe ::Trax::Core::Transformer do
     end
 
     class SubclassedPayloadTransformer < PayloadTransformer
+      property "thingg", :default => lambda{|r| "word1" }
+    end
+
+    class OtherSubclassedPayloadTransformer < PayloadTransformer
+      property "thingg", :default => lambda{|r| "word2" }
     end
   end
 
@@ -103,6 +108,18 @@ describe ::Trax::Core::Transformer do
 
     it {
       expect(subject["something"]).to eq "anything"
+      expect(subject["thingg"]).to eq "word1"
+    }
+  end
+
+  context "inheritance" do
+    subject {
+      OtherSubclassedPayloadTransformer.new(payload)
+    }
+
+    it {
+      expect(subject["something"]).to eq "anything"
+      expect(subject["thingg"]).to eq "word2"
     }
   end
 

--- a/spec/trax/core/transformer_spec.rb
+++ b/spec/trax/core/transformer_spec.rb
@@ -79,6 +79,9 @@ describe ::Trax::Core::Transformer do
         value + transformer.input["shipping"]["price"]
       end
     end
+
+    class SubclassedPayloadTransformer < PayloadTransformer
+    end
   end
 
   subject {
@@ -91,6 +94,16 @@ describe ::Trax::Core::Transformer do
         expect(subject.class.properties['stats'].is_nested?).to eq true
       }
     end
+  end
+
+  context "inheritance" do
+    subject {
+      SubclassedPayloadTransformer.new(payload)
+    }
+
+    it {
+      expect(subject["something"]).to eq "anything"
+    }
   end
 
   context "property mapping strategies" do


### PR DESCRIPTION
Fix transformer inheritance, only call dup if value being transformed is a hash