### PR TITLE
fixes nested structs, remove hashie version lock

### DIFF
--- a/lib/trax/core/fields.rb
+++ b/lib/trax/core/fields.rb
@@ -51,7 +51,7 @@ module Trax
       end
 
       def enumerables
-        @enumerables ||= all.select {|k,v| v.is_enumerable? }
+        @enumerables ||= all.select {|k,v| v.try(:is_enumerable?) }
       end
 
       def to_schema

--- a/trax_core.gemspec
+++ b/trax_core.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "hashie", '~>3.4.4'
+  spec.add_dependency "hashie"
   spec.add_dependency "activesupport"
   spec.add_dependency "activemodel"
   spec.add_dependency "wannabe_bool"


### PR DESCRIPTION
nested structs have been broken within rails model definitions when using jsonb for structs i.e. 
``` ruby
define_attributes do
  struct :something do
    struct :anything
  end
end
```
(oddly they worked when inheriting from Trax::Core::Blueprint, but didn't have time to dig into it) - this fixes the issue in trax_model